### PR TITLE
Allow setting a custom compilation command using `hook_compile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ The above method always uses the latest version of the buildpack code. To use a 
 
 #### Using Heroku CI
 
-This buildpack supports Heroku CI. To enable viewing test runs on Heroku, add [tapex](https://github.com/joshwlewis/tapex) to your project.
+This buildpack supports Heroku CI. 
+
+* To enable viewing test runs on Heroku, add [tapex](https://github.com/joshwlewis/tapex) to your project.
+* To detect compilation warnings use the `hook_compile` configuration option set to `mix compile --force --warnings-as-errors`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 * Consolidates protocols
 * Hex and rebar support
 * Caching of Hex packages, Mix dependencies and downloads
-* Pre & Post compilation hooks through `hook_pre_compile`, `hook_post_compile` configuration
-
+* Compilation procedure hooks through `hook_pre_compile`, `hook_compile`, `hook_post_compile` configuration
 
 #### Version support
 
@@ -77,6 +76,8 @@ hook_pre_fetch_dependencies="pwd"
 
 # A command to run right before compiling the app (after elixir, .etc)
 hook_pre_compile="pwd"
+
+hook_compile="mix compile --force --warnings-as-errors"
 
 # A command to run right after compiling the app
 hook_post_compile="pwd"

--- a/lib/app_funcs.sh
+++ b/lib/app_funcs.sh
@@ -98,7 +98,13 @@ function compile_app() {
 
   cd $build_path
   output_section "Compiling"
-  mix compile --force || exit 1
+
+  if [ -n "$hook_compile" ]; then
+     output_section "(using custom compile comand)"
+     $hook_compile || exit 1
+  else
+     mix compile --force || exit 1
+  fi
 
   mix deps.clean --unused
 


### PR DESCRIPTION
## Description

Allow setting a custom compilation command using `hook_compile`. See changed README.md file for more details.

### Use cases:

* common: add ` --warnings-as-errors` flag to `mix compile` while in Heroku CI to check that the compilation does not have any warnings
* very rare: run the compilation in a single thread (fixes multi-threading compilation issues with some code bases – as temporary solution before fixing the root cause of such problems)

## Testing

See that https://github.com/socialpaymentsbv/clubbase.io/pull/620 is working as expected.
Without the hook set it also works ([e.g.](https://dashboard.heroku.com/pipelines/b796c115-728c-4df6-a2a2-320929ac5942/tests/619)).